### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent_plugin_ecs_metadata_filter.gemspec
+++ b/fluent_plugin_ecs_metadata_filter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fluentd', '>= 0.12.0'
+  spec.add_dependency 'fluentd', '>= 0.14.0'
   spec.add_dependency 'lru_redux', '~> 1.1'
   spec.add_dependency 'httparty', '~> 0.14.0'
 

--- a/lib/fluent/plugin/filter_ecs_metadata.rb
+++ b/lib/fluent/plugin/filter_ecs_metadata.rb
@@ -1,8 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 
-require 'fluent/filter'
+require 'fluent/plugin/filter'
 
-module Fluent
+module Fluent::Plugin
   class ECSMetadataFilter < Filter
     Fluent::Plugin.register_filter('ecs_metadata', self)
 
@@ -33,7 +33,7 @@ module Fluent
     end
 
     def filter_stream(tag, es)
-      new_es   = MultiEventStream.new
+      new_es   = Fluent::MultiEventStream.new
       metadata = metadata_for_tag(tag)
 
       es.each do |time, record|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'fluent_ecs'
 
 require 'minitest/autorun'
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 
 require 'webmock/minitest'
 require 'vcr'


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,