### PR TITLE
Add fields key

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Configuration options for `fluent.conf` are:
 
 * `cache_size`     - Size of the cache of ECS container metadata which reduces requests to the API server  - default: `1000`
 * `cache_ttl`      - TTL in seconds for each cached element. Set to negative value to disable TTL eviction - default: `3600` (1 hour)
+* `fields_key`     - Key in the final record holding the metadata fields.  Set to "" to set fields in the record itself - default: `ecs`
 * `keys`           - Array of metadata keys that should be added to a log record                           - default: `docker_name`, `family`, `cluster`, `name` - **Available options:**
   + `cluster`
   + `container_instance_arn`

--- a/lib/fluent/plugin/filter_ecs_metadata.rb
+++ b/lib/fluent/plugin/filter_ecs_metadata.rb
@@ -40,7 +40,11 @@ module Fluent::Plugin
       es.each do |time, record|
         if metadata
           record = merge_log_json(record) if merge_json_logs?
-          record[@fields_key] = metadata.to_h
+          if @fields_key.empty?
+            record.merge! metadata.to_h
+          else
+            record[@fields_key] = metadata.to_h
+          end
         end
 
         new_es.add(time, record)

--- a/lib/fluent/plugin/filter_ecs_metadata.rb
+++ b/lib/fluent/plugin/filter_ecs_metadata.rb
@@ -9,6 +9,7 @@ module Fluent::Plugin
     config_param :cache_size,     :integer, default: 1000
     config_param :cache_ttl,      :integer, default: 60 * 60
     config_param :merge_json_log, :bool,    default: true
+    config_param :fields_key,     :string,  default: 'ecs'
     config_param :fields,         :array,
                  default:          %w(docker_name family cluster name),
                  value_type:      :string
@@ -39,7 +40,7 @@ module Fluent::Plugin
       es.each do |time, record|
         if metadata
           record = merge_log_json(record) if merge_json_logs?
-          record['ecs'] = metadata.to_h
+          record[@fields_key] = metadata.to_h
         end
 
         new_es.add(time, record)

--- a/test/plugin/filter_ecs_metadata_test.rb
+++ b/test/plugin/filter_ecs_metadata_test.rb
@@ -148,4 +148,18 @@ class ECSMetadataFilterTest < Minitest::Test
       assert_equal expected, es.map{|e| e.last}.first
     end
   end
+
+  def test_with_empty_field_key_merges_to_top_level
+    VCR.use_cassette('introspection') do
+      expected = {
+        'docker_name' => 'ecs-targaryen-2-daenerys-e4f1ee88ef81d28c5500',
+        'family'      => 'targaryen',
+        'cluster'     => 'westeros',
+        'name'        => 'daenerys'
+      }
+
+      es, = emit('fields_key ""')
+      assert_equal expected, es.map{|e| e.last}.first
+    end
+  end
 end

--- a/test/plugin/filter_ecs_metadata_test.rb
+++ b/test/plugin/filter_ecs_metadata_test.rb
@@ -134,4 +134,18 @@ class ECSMetadataFilterTest < Minitest::Test
       assert_match expected_log, driver.logs[0]
     end
   end
+
+  def test_with_field_key
+    VCR.use_cassette('introspection') do
+      expected = { 'metadata' => {
+        'docker_name' => 'ecs-targaryen-2-daenerys-e4f1ee88ef81d28c5500',
+        'family'      => 'targaryen',
+        'cluster'     => 'westeros',
+        'name'        => 'daenerys'
+      } }
+
+      es, = emit('fields_key metadata')
+      assert_equal expected, es.map{|e| e.last}.first
+    end
+  end
 end


### PR DESCRIPTION
Adds a config `fields_key` that allow users to change where the metadata lands in the final record, including merging the metadata at the top level of the record.

For example:

```
# unspecified results in the same output as today
# => {..., "ecs": {"field":"field_value"}}

fields_key "metadata"
# => {..., "metadata": {"field":"field_value"}}

fields_key ""
# => {..., "field":"field_value"}
```

This would help my situation where I want to use the [rewrite_tag_filter](https://github.com/fluent/fluent-plugin-rewrite-tag-filter) to add the task_id to the tag.  I don't know how to pull the task_id from a nested location, but I could do it if the fields were at the top level.  From prior experience with Elasticsearch, this may also simplify things when sending data there.