### PR TITLE
Add ecs_agent_uri configuration parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gem
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Configuration options for `fluent.conf` are:
 
 * `cache_size`     - Size of the cache of ECS container metadata which reduces requests to the API server  - default: `1000`
 * `cache_ttl`      - TTL in seconds for each cached element. Set to negative value to disable TTL eviction - default: `3600` (1 hour)
+* `ecs_agent_uri`  - Base address used to contact the ecs-agent
+                   - default: `http://localhost:51678/v1`
 * `fields_key`     - Key in the final record holding the metadata fields.  Set to "" to set fields in the record itself - default: `ecs`
 * `fields`         - Array of metadata fields that should be added to a log record                         - default: `docker_name`, `family`, `cluster`, `name` - **Available options:**
   + `cluster`

--- a/lib/fluent/plugin/filter_ecs_metadata.rb
+++ b/lib/fluent/plugin/filter_ecs_metadata.rb
@@ -8,6 +8,7 @@ module Fluent::Plugin
 
     config_param :cache_size,     :integer, default: 1000
     config_param :cache_ttl,      :integer, default: 60 * 60
+    config_param :ecs_agent_uri,  :string,  default: 'http://localhost:51678/v1'
     config_param :merge_json_log, :bool,    default: true
     config_param :fields_key,     :string,  default: 'ecs'
     config_param :fields,         :array,
@@ -29,6 +30,9 @@ module Fluent::Plugin
         c.cache_ttl  = @cache_ttl < 0 ? :none : @cache_ttl
         c.fields     = @fields
       end
+
+      FluentECS::Metadata.base_uri @ecs_agent_uri
+      FluentECS::Task.base_uri @ecs_agent_uri
 
       @tag_regexp_compiled = Regexp.compile(@tag_regexp)
     end


### PR DESCRIPTION
This PR adds the `ecs_agent_uri` configuration parameter to support container<>container communication via the docker bridge. For instance, when using running fluentd in a container, this would be set to `http://172.17.0.1:51678/v1`.